### PR TITLE
Improve assertion method call and fix Psalm issue

### DIFF
--- a/src/DbalSchema.php
+++ b/src/DbalSchema.php
@@ -45,6 +45,7 @@ final class DbalSchema
             ]
         );
         $table->addColumn('enabled', 'boolean');
+        /** @psalm-suppress DeprecatedMethod */
         if ('sqlite' === $this->platform->getName()) {
             $table->addColumn(
                 'strategies',

--- a/test/Cli/InitSchemaTest.php
+++ b/test/Cli/InitSchemaTest.php
@@ -42,14 +42,14 @@ class InitSchemaTest extends TestCase
         }
         $initSchema = new InitSchema(new DbalSchema($connection));
 
-        self::assertSame('pheature:dbal:init-toggle', $initSchema->getName());
-        self::assertSame('Create Pheature toggles database schema.', $initSchema->getDescription());
+        $this->assertSame('pheature:dbal:init-toggle', $initSchema->getName());
+        $this->assertSame('Create Pheature toggles database schema.', $initSchema->getDescription());
 
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
         $output->expects(self::once())
             ->method('writeLn')
             ->with('<info>Pheature Toggle database schema successfully created.</info>');
-        self::assertSame(0, $initSchema->run($input, $output));
+        $this->assertSame(0, $initSchema->run($input, $output));
     }
 }

--- a/test/Container/ConfigProviderTest.php
+++ b/test/Container/ConfigProviderTest.php
@@ -28,6 +28,6 @@ final class ConfigProviderTest extends TestCase
     {
         $actual = (new ConfigProvider())->__invoke();
 
-        self::assertSame(self::EXPECTED_CONFIG, $actual);
+        $this->assertSame(self::EXPECTED_CONFIG, $actual);
     }
 }

--- a/test/Container/InitSchemaFactoryTest.php
+++ b/test/Container/InitSchemaFactoryTest.php
@@ -39,7 +39,7 @@ class InitSchemaFactoryTest extends TestCase
             ->willReturn($connection);
         $factory = new InitSchemaFactory();
         $initSchema = $factory($container);
-        self::assertInstanceOf(InitSchema::class, $initSchema);
+        $this->assertInstanceOf(InitSchema::class, $initSchema);
     }
 
     public function testItShouldCreateInstanceOfInitSchemaStatically(): void
@@ -61,6 +61,6 @@ class InitSchemaFactoryTest extends TestCase
         }
 
         $initSchema = InitSchemaFactory::create($connection);
-        self::assertInstanceOf(InitSchema::class, $initSchema);
+        $this->assertInstanceOf(InitSchema::class, $initSchema);
     }
 }

--- a/test/DbalFeatureFactoryTest.php
+++ b/test/DbalFeatureFactoryTest.php
@@ -25,7 +25,7 @@ final class DbalFeatureFactoryTest extends TestCase
         );
         $factory = new DbalFeatureFactory($strategyFactory);
         $feature = $factory->create($featureData);
-        self::assertInstanceOf(Feature::class, $feature);
+        $this->assertInstanceOf(Feature::class, $feature);
     }
 
     public function getFeatureData(): array

--- a/test/Read/DbalFeatureFinderTest.php
+++ b/test/Read/DbalFeatureFinderTest.php
@@ -39,9 +39,9 @@ class DbalFeatureFinderTest extends TestCase
 
         $finder = new DbalFeatureFinder($connection, new DbalFeatureFactory($strategyFactory));
         $feature = $finder->get(self::FEATURE_ID);
-        self::assertSame(self::FEATURE_ID, $feature->id());
-        self::assertSame(true, $feature->isEnabled());
-        self::assertSame(0, $feature->strategies()->count());
+        $this->assertSame(self::FEATURE_ID, $feature->id());
+        $this->assertTrue($feature->isEnabled());
+        $this->assertSame(0, $feature->strategies()->count());
     }
 
     public function testItShouldFindAllFeaturesFromDatabase(): void
@@ -74,6 +74,6 @@ class DbalFeatureFinderTest extends TestCase
 
         $finder = new DbalFeatureFinder($connection, new DbalFeatureFactory($strategyFactory));
         $features = $finder->all();
-        self::assertCount(2, $features);
+        $this->assertCount(2, $features);
     }
 }

--- a/test/Write/DbalFeatureFactoryTest.php
+++ b/test/Write/DbalFeatureFactoryTest.php
@@ -14,7 +14,7 @@ final class DbalFeatureFactoryTest extends TestCase
     public function testItShouldCreateInstancesOfFeatureFromDatabaseRepresentation(array $featureData, int $expectedStrategies): void
     {
         $feature = DbalFeatureFactory::createFromDbalRepresentation($featureData);
-        self::assertCount($expectedStrategies, $feature->strategies());
+        $this->assertCount($expectedStrategies, $feature->strategies());
     }
 
     public function getSomeFeatures(): Generator


### PR DESCRIPTION
# Changed log

- Using the `assertTrue` to assert expected is `true`.
- To be consistency, using the `$this` to make all assertion methods call.
- Adding the `@psalm-suppress DeprecatedMethod` annotation for deprecated Doctrine DBAL `AbstractPlatform::getName` method.