### PR TITLE
[#17][dbal-toggle] Add CLI option to InitSchema to create schema if not exists

### DIFF
--- a/src/Cli/InitSchema.php
+++ b/src/Cli/InitSchema.php
@@ -7,6 +7,7 @@ namespace Pheature\Dbal\Toggle\Cli;
 use Pheature\Dbal\Toggle\DbalSchema;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class InitSchema extends Command
@@ -22,12 +23,18 @@ final class InitSchema extends Command
     protected function configure(): void
     {
         $this->setName('pheature:dbal:init-toggle')
-            ->setDescription('Create Pheature toggles database schema.');
+            ->setDescription('Create Pheature toggles database schema.')
+            ->addOption(
+                'init-if-not-exists',
+                null,
+                InputOption::VALUE_NONE,
+                'Initialize DB toggle schema if not exists'
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->dbalSchema->__invoke();
+        $this->dbalSchema->__invoke($input->getOption('init-if-not-exists') ?? false);
 
         $output->writeln('<info>Pheature Toggle database schema successfully created.</info>');
 

--- a/src/Cli/InitSchema.php
+++ b/src/Cli/InitSchema.php
@@ -34,7 +34,8 @@ final class InitSchema extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->dbalSchema->__invoke($input->getOption('init-if-not-exists') ?? false);
+        $initializeIfNotExists = (bool)$input->getOption('init-if-not-exists');
+        $this->dbalSchema->__invoke($initializeIfNotExists);
 
         $output->writeln('<info>Pheature Toggle database schema successfully created.</info>');
 

--- a/src/DbalSchema.php
+++ b/src/DbalSchema.php
@@ -63,7 +63,7 @@ final class DbalSchema
             ]
         );
         $table->addColumn('enabled', 'boolean');
-        if ('sqlite' === $this->platform->getName()) {
+        if ($this->isSqlite()) {
             $table->addColumn(
                 'strategies',
                 'json',
@@ -97,5 +97,36 @@ final class DbalSchema
         }
 
         return true;
+    }
+
+    private function isSqlite(): bool
+    {
+        $driver = $this->connection->getDriver();
+
+        if (
+            class_exists(\Doctrine\DBAL\Driver\PDOSqlite\Driver::class)
+            && $driver instanceof \Doctrine\DBAL\Driver\PDOSqlite\Driver
+        ) {
+            return true;
+        }
+
+        if (
+            class_exists(\Doctrine\DBAL\Driver\PDO\SQLite\Driver::class)
+            && $driver instanceof \Doctrine\DBAL\Driver\PDO\SQLite\Driver
+        ) {
+            return true;
+        }
+
+        if (
+            class_exists(\Doctrine\DBAL\Driver::class)
+            && $driver instanceof \Doctrine\DBAL\Driver
+        ) {
+            /**
+             * @psalm-suppress DeprecatedMethod
+             */
+            return 'sqlite' === $driver->getDatabasePlatform()->getName();
+        }
+
+        return false;
     }
 }

--- a/test/DbalSchemaTest.php
+++ b/test/DbalSchemaTest.php
@@ -6,24 +6,37 @@ namespace Pheature\Test\Dbal\Toggle;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\SchemaException;
 use Pheature\Dbal\Toggle\DbalSchema;
 use PHPUnit\Framework\TestCase;
 
 class DbalSchemaTest extends TestCase
 {
+    private string $dbPath;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = realpath(__DIR__) . '/test.sqlite';
+        touch($this->dbPath);
+        $this->connection = DriverManager::getConnection(['url' => 'sqlite:///' . $this->dbPath]);
+    }
+
+    protected function tearDown(): void
+    {
+        unlink($this->dbPath);
+    }
+
     public function testItShouldCreateValidDatabaseSchema(): void
     {
-        $dbPath = realpath(__DIR__) . '/test.sqlite';
-        touch($dbPath);
+        $schema = new DbalSchema($this->connection);
 
-        $connection = DriverManager::getConnection(['url' => 'sqlite:///' . $dbPath]);
-        $schema = new DbalSchema($connection);
-        $schema();
+        $initializeIfNotExists = false;
+        $schema($initializeIfNotExists);
 
-        $statement = $connection->executeQuery('SELECT `sql` FROM sqlite_master sm WHERE sm.name = "pheature_toggles"');
+        $statement = $this->connection->executeQuery('SELECT `sql` FROM sqlite_master sm WHERE sm.name = "pheature_toggles"');
 
         $tableSchema = method_exists($statement, 'fetchOne') ? $statement->fetchOne() : $statement->fetch()['sql'];
-        unlink($dbPath);
 
         $this->assertStringContainsString('CREATE TABLE pheature_toggles', $tableSchema);
         $this->assertStringContainsString('feature_id VARCHAR(36) NOT NULL', $tableSchema);
@@ -33,5 +46,31 @@ class DbalSchemaTest extends TestCase
         $this->assertStringContainsString('created_at DATETIME NOT NULL --(DC2Type:datetime_immutable)', $tableSchema);
         $this->assertStringContainsString('updated_at DATETIME DEFAULT NULL --(DC2Type:datetime_immutable)', $tableSchema);
         $this->assertStringContainsString('PRIMARY KEY(feature_id))', $tableSchema);
+    }
+
+    public function testItShouldThrowAnExceptionIfSchemaTableAlreadyExists(): void
+    {
+        $schema = new DbalSchema($this->connection);
+
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessage("The table with name 'public.pheature_toggles' already exists.");
+
+        $initializeIfNotExists = false;
+        $schema($initializeIfNotExists);
+        $schema($initializeIfNotExists);
+    }
+
+    public function testItShouldDoNothingIfSchemaTableAlreadyExistsSettingInitializeIfNotExistsToTrue(): void
+    {
+        $schema = new DbalSchema($this->connection);
+
+        $initializeIfNotExists = true;
+        $schema($initializeIfNotExists);
+        $schema($initializeIfNotExists);
+
+        $statement = $this->connection->executeQuery('SELECT `sql` FROM sqlite_master sm WHERE sm.name = "pheature_toggles"');
+
+        $tableSchema = method_exists($statement, 'fetchOne') ? $statement->fetchOne() : $statement->fetch()['sql'];
+        $this->assertStringContainsString('CREATE TABLE pheature_toggles', $tableSchema);
     }
 }


### PR DESCRIPTION
Closes #17 

Final output:

![image](https://user-images.githubusercontent.com/5933658/154136050-bc3849b7-2701-4984-9002-9975a7f1562c.png)

This MR also makes compatible with version `3.0` where the `Doctrine\DBAL\Driver::getName()` method is removed (see: https://github.com/doctrine/dbal/blob/3.3.x/UPGRADE.md#bc-break-doctrinedbaldrivergetname-removed).