### PR TITLE
[#19][dbal-toggle] Throw DbalFeatureNotFound exception instead of InvalidArgumentException

### DIFF
--- a/src/Read/DbalFeatureFinder.php
+++ b/src/Read/DbalFeatureFinder.php
@@ -6,13 +6,12 @@ namespace Pheature\Dbal\Toggle\Read;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Result;
-use InvalidArgumentException;
 use Pheature\Core\Toggle\Read\Feature;
 use Pheature\Core\Toggle\Read\FeatureFinder;
+use Pheature\Dbal\Toggle\Exception\DbalFeatureNotFound;
 
 use function array_map;
 use function is_array;
-use function sprintf;
 
 /**
  * @psalm-import-type DbalFeature from \Pheature\Dbal\Toggle\Read\DbalFeatureFactory
@@ -39,7 +38,7 @@ final class DbalFeatureFinder implements FeatureFinder
         /** @var DbalFeature|false $feature */
         $feature = $statement->fetchAssociative();
         if (false === is_array($feature)) {
-            throw new InvalidArgumentException(sprintf('Not feature found for given id %s', $featureId));
+            throw DbalFeatureNotFound::withId($featureId);
         }
 
         return $this->featureFactory->create($feature);

--- a/test/Exception/DbalFeatureNotFoundTest.php
+++ b/test/Exception/DbalFeatureNotFoundTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Pheature\Test\Dbal\Toggle\Exception;
+
+use InvalidArgumentException;
+use Pheature\Core\Toggle\Exception\FeatureNotFoundException;
+use Pheature\Dbal\Toggle\Exception\DbalFeatureNotFound;
+use PHPUnit\Framework\TestCase;
+
+final class DbalFeatureNotFoundTest extends TestCase
+{
+    private const FEATURE_ID = 'some_feature_id';
+
+    public function testItShouldImplementFeatureNotFoundException(): void
+    {
+        $exception = DbalFeatureNotFound::withId(self::FEATURE_ID);
+
+        $this->assertInstanceOf(FeatureNotFoundException::class, $exception);
+        $this->assertInstanceOf(InvalidArgumentException::class, $exception);
+    }
+
+    public function testItShouldContainTheCorrectErrorMessage(): void
+    {
+        $exception = DbalFeatureNotFound::withId(self::FEATURE_ID);
+
+        $expectedMessage = sprintf('There is not feature with id %s in database.', self::FEATURE_ID);
+        $this->assertSame($expectedMessage, $exception->getMessage());
+    }
+}


### PR DESCRIPTION
Closes #19 

Blocked by #18 (has the fix for psalm error)